### PR TITLE
save all weights every trial if specified at commandline

### DIFF
--- a/src/control.cpp
+++ b/src/control.cpp
@@ -432,6 +432,7 @@ void Control::runSession(struct gui *gui)
 		}
 		// save gr rasters into new file every trial 
 		save_gr_raster();
+		save_weights();
 		trial++;
 	}
 	if (run_state == NOT_IN_RUN) std::cout << "[INFO]: Simulation terminated.\n";
@@ -493,6 +494,24 @@ void gen_gr_sample(int gr_indices[], int sample_size, int data_size)
 			chosen[index] = true;
 			counter++;
 		} 
+	}
+}
+
+void Control::save_weights()
+{
+	if (!pf_pc_weights_file.empty())
+	{
+		std::string trial_pfpc_weights_name = OUTPUT_DATA_PATH + get_file_basename(pf_pc_weights_file)
+											+ "_trial_" + std::to_string(trial) + "." + BIN_EXT;
+		std::cout << "[INFO]: Saving granule to purkinje weights to file...\n";
+		save_pfpc_weights_to_file(trial_pfpc_weights_name);
+	}
+	if (!mf_nc_weights_file.empty())
+	{
+		std::string trial_mfnc_weights_name = OUTPUT_DATA_PATH + get_file_basename(mf_nc_weights_file)
+											+ "_trial_" + std::to_string(trial) + "." + BIN_EXT;
+		std::cout << "[INFO]: Saving mossy fiber to deep nucleus weigths to file...\n";
+		save_mfdcn_weights_to_file(trial_mfnc_weights_name);
 	}
 }
 

--- a/src/control.h
+++ b/src/control.h
@@ -190,6 +190,7 @@ class Control
 		void calculate_firing_rates(float onset_cs, float offset_cs);
 		void fill_rasters(uint32_t raster_counter, uint32_t psth_counter, struct gui *gui);
 		void fill_psths(uint32_t psth_counter);
+		void save_weights();
 		void save_gr_raster();
 		void save_rasters();
 		void save_psths();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,14 +41,10 @@ int main(int argc, char **argv)
 		{
 			control->runSession(NULL);
 			if (!p_cl.output_sim_file.empty())
+			{
 				std::cout << "[INFO]: Saving simulation to file...\n";
 				control->save_sim_to_file(p_cl.output_sim_file);
-			if (!control->pf_pc_weights_file.empty())
-				std::cout << "[INFO]: Saving granule to purkinje weigths to file...\n";
-				control->save_pfpc_weights_to_file(p_cl.weights_files["PFPC"]);
-			if (!control->mf_nc_weights_file.empty())
-				std::cout << "[INFO]: Saving mossy fiber to deep nucleus weigths to file...\n";
-				control->save_mfdcn_weights_to_file(p_cl.weights_files["MFNC"]);
+			}
 		}
 		else if (p_cl.vis_mode == "GUI")
 		{


### PR DESCRIPTION
this commit adds in a function 'save_weights' that checks whether the control attributes for the weights files are nonempty, and if so, saves the corresponding weights. The function is called at the end of each trial, effectively implementing a monitoring of the weights states after each trial.

Note that in a later version this function will be altered to accommodate the auto-creation of file names.