### PR TITLE
added pre_cs_collection_tbins const variable in control class

### DIFF
--- a/src/control.cpp
+++ b/src/control.cpp
@@ -7,7 +7,6 @@
 #include "array_util.h"
 #include "gui.h" /* tenuous inclide at best :pogO: */
 
-
 const std::string BIN_EXT = "bin";
 const std::string CELL_IDS[NUM_CELL_TYPES] = {"MF", "GR", "GO", "BC", "SC", "PC", "IO", "NC"}; 
 
@@ -334,11 +333,11 @@ void Control::runSession(struct gui *gui)
 		std::string trialName = td.trial_names[trial];
 
 		uint32_t useCS        = td.use_css[trial];
-		uint32_t onsetCS      = td.cs_onsets[trial];
+		uint32_t onsetCS      = pre_collection_ts + td.cs_onsets[trial];
 		uint32_t csLength     = td.cs_lens[trial];
 		uint32_t percentCS    = td.cs_percents[trial];
 		uint32_t useUS        = td.use_uss[trial];
-		uint32_t onsetUS      = td.us_onsets[trial];
+		uint32_t onsetUS      = pre_collection_ts + td.us_onsets[trial];
 		
 		int PSTHCounter = 0;
 		float gGRGO_sum = 0;

--- a/src/control.h
+++ b/src/control.h
@@ -80,7 +80,7 @@ class Control
 		float inputStrength = 0.0;
 
 		// sim params -> TODO: place in simcore
-		int gpuIndex = 2;
+		int gpuIndex = 0;
 		int gpuP2    = 2;
 
 		int trial;
@@ -124,7 +124,7 @@ class Control
 		float fracOverlap = 0.2;
 
 		int trialTime = 0; 
-	
+		const uint32_t pre_collection_ts = 2000;
 		// raster measurement params. 
 		int msPreCS = 0;
 		int msPostCS = 0;


### PR DESCRIPTION
used on per-trial basis to offset cs onset and us onset by a constant amount. this constant amount is meant as a equilibriation time and for now has been implemented as 2000ms.